### PR TITLE
Fixing num images in ImageNet Sketch

### DIFF
--- a/src/eval_settings/imagenet_sketch.py
+++ b/src/eval_settings/imagenet_sketch.py
@@ -6,6 +6,6 @@ registry.add_eval_setting(
     EvalSetting(
         name = 'imagenet-sketch',
         dataset = StandardDataset(name='imagenet-sketch'),
-        size = 50000,
+        size = 50889,
     )
 )


### PR DESCRIPTION
```
find . -type f -name "*.JPEG" | wc -l
50889
```