### PR TITLE
Fix scripts for downloading resources from google server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,6 @@ plotly>=4.8.2
 timm>=0.4.12
 dill>=0.3.3
 scikit-learn==0.23.2
+gdown
 git+https://github.com/tensorflow/cleverhans.git#egg=cleverhans
 git+https://github.com/openai/CLIP.git

--- a/src/mldb/model_repository.py
+++ b/src/mldb/model_repository.py
@@ -27,8 +27,11 @@ DB_DUMP_URL = 'https://vasa.millennium.berkeley.edu:9000/robustness-eval/robustn
 def download_db():
     if not exists(join(s3_utils.default_cache_root_path, 'robustness_evaluation.db')):
         print('downloading database dump...')
-        subprocess.run(['wget', '-P', s3_utils.default_cache_root_path, DB_DUMP_URL, '--no-check-certificate'], check=True)
-
+        try:
+            subprocess.run(['wget', '-P', s3_utils.default_cache_root_path, DB_DUMP_URL, '--no-check-certificate'], check=True)
+        except:
+            import gdown
+            gdown.download("https://drive.google.com/uc?id=17XOxNxRqB_xMcHsAoewNmtuzKtdlpmzV", join(s3_utils.default_cache_root_path, 'robustness_evaluation.db'), quiet=False)
 
 def gen_short_uuid(num_chars=None):
     num = uuid.uuid4().int

--- a/src/mldb/s3_utils.py
+++ b/src/mldb/s3_utils.py
@@ -79,7 +79,7 @@ def key_exists(bucket, key):
     # Return true if a key exists in s3 bucket
     # TODO: return None from the get functions if the key doesn't exist?
     #       (this would avoid one round-trip to S3)
-    client = get_s3_client()
+    client = get_s3_client_google()
     try:
         client.head_object(Bucket=bucket, Key=key)
         return True

--- a/src/mldb/s3_utils.py
+++ b/src/mldb/s3_utils.py
@@ -74,22 +74,28 @@ def get_s3_client_google():
 # default is vasa, but some older objects are stored on google
 get_s3_client = get_s3_client_vasa
 
-
 def key_exists(bucket, key):
     # Return true if a key exists in s3 bucket
     # TODO: return None from the get functions if the key doesn't exist?
     #       (this would avoid one round-trip to S3)
-    client = get_s3_client_google()
+    client = get_s3_client()
+
     try:
         client.head_object(Bucket=bucket, Key=key)
         return True
-    except botocore.exceptions.ClientError as exc:
-        if exc.response['Error']['Code'] != '404':
+    except (botocore.exceptions.EndpointConnectionError, botocore.exceptions.SSLError, botocore.exceptions.ClientError):
+        try:
+            client = get_s3_client_google()
+            client.head_object(Bucket=bucket, Key=key)
+            return True
+        except botocore.exceptions.ClientError as exc:
+            if exc.response['Error']['Code'] != '404':
+                raise
+            return False
+        except:
             raise
-        return False
     except:
         raise
-
 
 def get_s3_object_bytes_parallel(keys, *,
                                  bucket,


### PR DESCRIPTION
Fixes #11: Now works out of the box for downloading and evaluating models. Tested for imagenet val and objectnet on resnet50 models with:

```bash
python eval.py --gpus 0 --models resnet50 --eval-settings val objectnet-1.0-beta
```

Of course this assumes the google server is more reliable, and should always be the default one going forward!